### PR TITLE
don't install packages for CI jobs that don't need them

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,9 +14,6 @@ jobs:
       - name: Install Rust
         run: rustup show
       - uses: Swatinem/rust-cache@v2
-      - name: Install packages
-        run: |
-          sudo apt-get install llvm-14-tools
       - run: cargo clippy --manifest-path crates/Cargo.toml --all-features --all-targets -- -D warnings
   
   test:
@@ -53,9 +50,6 @@ jobs:
       - name: Install Rust
         run: rustup show
       - uses: Swatinem/rust-cache@v2
-      - name: Install packages
-        run: |
-          sudo apt-get install llvm-14-tools
       - run: cargo doc --manifest-path crates/Cargo.toml
 
   success:


### PR DESCRIPTION
Static analysis like clippy or formatting doesn't need llvm tools.